### PR TITLE
rmv getChangesToRecord persistence method (historical artifact)

### DIFF
--- a/persistence/couchdb/index.js
+++ b/persistence/couchdb/index.js
@@ -110,9 +110,6 @@ couchdbPersistence.prototype.getChanges = function(req) {
   });
 };
 
-couchdbPersistence.prototype.getChangesToRecord = function(change) {
-};
-
 couchdbPersistence.prototype.resetChanges = function(change) {
   var dbUrl = this.dbUrl;
   return request({

--- a/persistence/memory/index.js
+++ b/persistence/memory/index.js
@@ -29,12 +29,6 @@ MemoryPersistence.prototype.getChanges = function(req) {
   }
 };
 
-MemoryPersistence.prototype.getChangesToRecord = function(storeName, key) {
-  return store[storeName].filter(function(change) {
-    return change.key === key;
-  });
-};
-
 MemoryPersistence.prototype.resetChanges = function() {
   this.changes = {};
   return Promise.resolve();

--- a/persistence/mysql/index.js
+++ b/persistence/mysql/index.js
@@ -87,9 +87,6 @@ mysqlPersistence.prototype.getChanges = function(req) {
   });
 };
 
-mysqlPersistence.prototype.getChangesToRecord = function(change) {
-};
-
 mysqlPersistence.prototype.resetChanges = function(change) {
   var con = this.connection;
   return con.queryAsync('DELETE FROM synceddb_changes').then(function() {

--- a/persistence/postgresql/index.js
+++ b/persistence/postgresql/index.js
@@ -79,9 +79,6 @@ pgPersistence.prototype.getChanges = function(req) {
   });
 };
 
-pgPersistence.prototype.getChangesToRecord = function(change) {
-};
-
 pgPersistence.prototype.resetChanges = function(change) {
   var client;
   return getClient(this).then(function(c) {


### PR DESCRIPTION
Addresses part of issue #6 related to historical artifact in persistence (`getChangesToRecord`)