### PR TITLE
Make the todo example works out of the box

### DIFF
--- a/API.md
+++ b/API.md
@@ -470,6 +470,7 @@ server.handle.create(function(clientData, store, msg, respond, broadcast) {
 
 __Arguments__
 * `options` (object) - options object with the following properties
+  * `server` (HTTP server) - the HTTP server created with http.createServer(), otherwise it will create it
   * `port` (integer) - the port that the Web Socket server should listen at
   * `store` (object) - an instance of a persistence strategy
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -99,7 +99,12 @@ class Server {
     const server = this;
     server.resetHandlers();
     server.store = opts.store;
-    server.wss = new WebSocketServer({port: opts.port || 8080});
+    if (opts.server) {
+      server.wss = new WebSocketServer({server: opts.server});
+    }
+    else {
+      server.wss = new WebSocketServer({port: opts.port || 8080});
+    }
     server.wss.on('connection', (ws) => {
       ws.clientData = {};
       const handleMsg = handleMsgFn(server, ws);

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -7,6 +7,7 @@ Try it
 Get the repository
 ```
 git clone https://github.com/paldepind/synceddb.git
+cd synceddb/
 ```
 Get dependencies
 ```
@@ -14,7 +15,7 @@ npm run build
 ```
 Go to the todo example directory:
 ```
-cd synceddb/examples/todo
+cd examples/todo
 ```
 Start server
 ```

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -7,11 +7,14 @@ Try it
 Get the repository
 ```
 git clone https://github.com/paldepind/synceddb.git
-cd synceddb/examples/todo
 ```
 Get dependencies
 ```
-npm install
+npm run build
+```
+Go to the todo example directory:
+```
+cd synceddb/examples/todo
 ```
 Start server
 ```

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -6,8 +6,7 @@ Try it
 
 Get the repository
 ```
-git clone https://github.com/paldepind/synceddb.git
-cd synceddb/
+git clone https://github.com/paldepind/synceddb.git && cd synceddb/
 ```
 Get dependencies
 ```

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -10,7 +10,7 @@ git clone https://github.com/paldepind/synceddb.git && cd synceddb/
 ```
 Get dependencies
 ```
-npm run build
+npm install
 ```
 Go to the todo example directory:
 ```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "lint": "eslint --fix --ignore-path .gitignore \"**/*.js\"",
     "test": "pwd; ls; bash ./runtests.sh",
-    "build": "npm i; cd backend; npm i; cd ../client; npm i; webpack"
+    "prepublish": "cd backend; npm i; cd ../client; npm i"
   },
   "author": "Simon Friis Vindum",
   "license": "MIT",
@@ -11,7 +11,6 @@
   },
   "homepage": "https://github.com/paldepind/synceddb",
   "devDependencies": {
-    "eslint": "^2.8.0",
-    "webpack": "^1.13.1"
+    "eslint": "^2.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "scripts": {
     "lint": "eslint --fix --ignore-path .gitignore \"**/*.js\"",
-    "test": "pwd; ls; bash ./runtests.sh"
+    "test": "pwd; ls; bash ./runtests.sh",
+    "build": "npm i; cd backend; npm i; cd ../client; npm i; webpack"
   },
   "author": "Simon Friis Vindum",
   "license": "MIT",
@@ -10,6 +11,7 @@
   },
   "homepage": "https://github.com/paldepind/synceddb",
   "devDependencies": {
-    "eslint": "^2.8.0"
+    "eslint": "^2.8.0",
+    "webpack": "^1.13.1"
   }
 }


### PR DESCRIPTION
The todo example needs some files built with webpack. I've slightly change the main package.json to permit a global `npm run build`. 