### PR TITLE
Pass req to handlers

### DIFF
--- a/API.md
+++ b/API.md
@@ -480,10 +480,11 @@ A new server.
 __Example__
 
 ```javascript
-var store = new MemoryPersistence();
-var server = new Server({
-  port: 3001,
-  persistence: new MemoryPersistence(),
+MemoryPersistence.create().then(function(persistence) {
+  var server = new Server({
+    port: 3001,
+    persistence: persistence
+  });
 });
 ```
 

--- a/API.md
+++ b/API.md
@@ -471,9 +471,11 @@ server.handle.create(function(clientData, store, msg, respond, broadcast) {
 
 __Arguments__
 * `options` (object) - options object with the following properties
+  * `store` (object) - an instance of a persistence strategy
   * `server` (HTTP server) - the HTTP server created with http.createServer(), otherwise it will create it
   * `port` (integer) - the port that the Web Socket server should listen at
-  * `store` (object) - an instance of a persistence strategy
+
+Besides `options.store`, `options` object is also passed as an argument of `ws.Server` constructor. See [the full document of available arguments](https://github.com/websockets/ws/blob/master/doc/ws.md#new-wsserveroptions-callback).
 
 __Returns__
 A new server.

--- a/API.md
+++ b/API.md
@@ -444,8 +444,9 @@ at construction.
 
 __Properties__
 
-* `handlers` (object) - a mapper from message types to handler functions,
-  the handler is called like this: `handler(clientData, store, msg, sendFn, broadcastFn)`
+* `handlers` (object) - a mapper from message types to handler functions.
+  the handler is called like this: `handler(clientData, store, msg, sendFn, broadcastFn, opt_upgradeReq)`.
+  `opt_upgradeReq` is passed only when `server` is specified to the constructor.
 
 ### Server.defaultHandlers
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/paldepind/synceddb",
   "dependencies": {
+    "blacklist": "^1.1.2",
     "ws": "^0.8.0"
   },
   "devDependencies": {

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,4 +1,5 @@
 'use strict';
+const blacklist = require('blacklist');
 const WebSocketServer = require('ws').Server;
 
 const handleCreateMsg = (clientData, store, msg, respond, broadcast) => {
@@ -98,12 +99,9 @@ class Server {
   constructor(opts) {
     this.resetHandlers();
     this.store = opts.store;
-    if (opts.server) {
-      this.wss = new WebSocketServer({server: opts.server});
-    }
-    else {
-      this.wss = new WebSocketServer({port: opts.port || 8080});
-    }
+    const wssArg = blacklist(opts, 'store');
+    wssArg.port = wssArg.port || 8080;
+    this.wss = new WebSocketServer(wssArg);
     this.wss.on('connection', (ws) => {
       ws.clientData = {};
       const handleMsg = handleMsgFn(this, ws);

--- a/backend/server.js
+++ b/backend/server.js
@@ -89,7 +89,7 @@ function handleMsgFn(server, ws) {
   return (msg) => {
     const data = JSON.parse(msg);
     if (data.type && data.type in server.handlers) {
-      server.handlers[data.type](ws.clientData, server.store, data, s, b);
+      server.handlers[data.type](ws.clientData, server.store, data, s, b, ws.upgradeReq);
     }
   };
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -96,18 +96,17 @@ function handleMsgFn(server, ws) {
 
 class Server {
   constructor(opts) {
-    const server = this;
-    server.resetHandlers();
-    server.store = opts.store;
+    this.resetHandlers();
+    this.store = opts.store;
     if (opts.server) {
-      server.wss = new WebSocketServer({server: opts.server});
+      this.wss = new WebSocketServer({server: opts.server});
     }
     else {
-      server.wss = new WebSocketServer({port: opts.port || 8080});
+      this.wss = new WebSocketServer({port: opts.port || 8080});
     }
-    server.wss.on('connection', (ws) => {
+    this.wss.on('connection', (ws) => {
       ws.clientData = {};
-      const handleMsg = handleMsgFn(server, ws);
+      const handleMsg = handleMsgFn(this, ws);
       handleMsg('{"type":"connect"}');
       ws.on('message', handleMsg);
     });


### PR DESCRIPTION
For flexible authentication, we need follows:

- [Server handlers](https://github.com/paldepind/synceddb/blob/master/API.md#server) wants `req` to deal with session
  - When we specify `server` to a web socket server of syncedDB, `ws`module associates a web socket request with a http request
  - This is useful when we want to refer to session in synceddb handlers
- Passing `verifyClient` to [ws.Server](https://github.com/websockets/ws/blob/master/doc/ws.md#new-wsserveroptions-callback)
  - to verify authentication at one place

This is a short example to use session in handlers with using npm Express. (I don't guarantee, I did't run)

```javascript
const http = require('http');
const express = require('express');
const cookieParser = require('cookie-parser');
const session = require('express-session');
const MemoryPersistence = require('synceddb-persistence-memory');
const SyncedDBBackend = require('synceddb-server');

const app = express();
const server = http.createServer(app);
const sessionParser = session({
  secret: 'baaa',
  resave: false,
  saveUninitialized: true
});

app.set('port', 3000);
app.use(cookieParser());

MemoryPersistence.create().then((p) => {
  const ws = new SyncedDBBackend({
    store: p,
    server: server,
    verifyClient: (info, done) => {
      const {req} = info;
      sessionParser(req, null, () => {
        console.log(req.session); // session available
        done(!!req.sesion.user); // If true, a user accepts a handshake.
      });
    }
  });
  ws.handlers.create = (clientData, store, msg, respond, broadcast, req) => {
    sessionParser(req, null, () => {
      console.log(req.session); // session available
      req.session.user.type; // We can change what we do in terms of a user state.
    });
  };
  server.listen(port);
});
```